### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ version: '3'
 services:
   fire_seq_search_server:
     image: ghcr.io/endle/fireseqsearch:latest
+    env_file: .env
     environment:
       - NOTEBOOK_DIR
     restart: always
     ports:
       - "127.0.0.1:3030:3030"
     volumes:
-      - ${NOTEBOOK_DIR}:${NOTEBOOK_DIR}
+      - ${NOTEBOOK_DIR}:${NOTEBOOK_DIR}:Z


### PR DESCRIPTION
Hi @Endle !
I tried to deploy your docker container with Podman, but I was getting an error because the notebook directory was not defined. This is because the *.env* file was not called in the `docker-compose` file.
Besides that, since I was running the container with Podman, and thus it is run without root permissions, the notebook files could not be accessed due to permissions errors.

Fix docker compose file:
1. Loads *.env* file
2. Fixes permission problems for the container to access files (in rootless containers like Podman)