### PR TITLE
Auto-download bge-m3 llamafile for zero-config embedding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,12 @@ glance.
 - **Backend:** subprocess `llama-server` by default; `--embed-endpoint` /
   `--chat-endpoint` point at a pre-running server (Ollama, remote llama) as
   a first-class alternative.
+- **Embed model is zero-config:** with no `--embed-model` and no
+  `--embed-endpoint`, the server auto-downloads a pinned `bge-m3` llamafile
+  (URL + SHA-256 in `llm_backend/model_fetch.rs`) into
+  `~/.cache/fire_seq_search` and spawns it. The `.llamafile` extension is what
+  switches `process.rs` into llamafile mode (no `--model` arg). An explicit
+  `--embed-model PATH` overrides; bump all three pin constants together.
 - **One chat backend, shared between summarizer and `/ask`.** Deliberate —
   one process to warm, one set of args to tune. If quality demands more, the
   lever is `--chat-endpoint` pointed at a bigger server, which upgrades both

--- a/README.md
+++ b/README.md
@@ -35,17 +35,22 @@ until the LLM backend answers.
 ### 1. Local LLM backend
 
 The server talks to an OpenAI-compatible HTTP backend for embeddings and
-chat. The embedding model is **`bge-m3`** (Q4_K_M GGUF, 1024-dim, ~700 MB) —
-chosen and pinned for retrieval quality. Any reasonable instruct-tuned chat
-model works.
+chat. The embedding model is **`bge-m3`** (1024-dim, multilingual) — chosen
+and pinned for retrieval quality. Any reasonable instruct-tuned chat model
+works.
 
-Download both GGUFs and drop them in `~/llm/` — that's where the server
-looks by default:
+**Embedding is zero-config.** On first run the server auto-downloads a pinned,
+self-contained `bge-m3` llamafile (~723 MB) into `~/.cache/fire_seq_search`
+(verified by SHA-256) and launches it for you. There's nothing to install for
+embeddings — the only model you choose is the chat model.
 
-- `~/llm/bge-m3-Q4_K_M.gguf` (embedding)
+Drop the chat GGUF in `~/llm/` — that's where the server looks by default:
+
 - `~/llm/Qwen3.5-9B-UD-Q4_K_XL.gguf` (chat)
 
-Override with `--embed-model` / `--chat-model` if you keep them elsewhere.
+Override the chat model with `--chat-model` if you keep it elsewhere. To use
+your own embedding model instead of the auto-downloaded one, pass
+`--embed-model /path/to/model` (GGUF or llamafile).
 
 By default the server spawns its own `llama-server`; see
 [`build_llama_server.sh`](build_llama_server.sh) and

--- a/fire_seq_search_server/Cargo.toml
+++ b/fire_seq_search_server/Cargo.toml
@@ -67,6 +67,10 @@ thiserror = "1"
 # Indexer (phase 2)
 rusqlite = { version = "0.31", features = ["bundled"] }
 blake3 = "1"
+# SHA-256 for verifying the pinned auto-downloaded bge-m3 llamafile. (Note
+# GitHub Releases publishes asset digests as SHA-256, hence sha2 here rather
+# than reusing blake3.)
+sha2 = "0.10"
 walkdir = "2"
 
 [dev-dependencies]

--- a/fire_seq_search_server/deny.toml
+++ b/fire_seq_search_server/deny.toml
@@ -21,6 +21,7 @@ ignore = [
     { id = "RUSTSEC-2025-0056", reason = "adler unmaintained: transitive via miniz_oxide" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained: transitive via reqwest" },
     { id = "RUSTSEC-2026-0007", reason = "bytes BytesMut overflow: transitive via hyper/reqwest" },
+    { id = "RUSTSEC-2026-0187", reason = "lopdf stack overflow on deeply nested PDFs: transitive via pdf-extract" },
 ]
 
 

--- a/fire_seq_search_server/src/llm_backend/mod.rs
+++ b/fire_seq_search_server/src/llm_backend/mod.rs
@@ -1,3 +1,4 @@
+pub mod model_fetch;
 pub mod process;
 
 use std::path::PathBuf;

--- a/fire_seq_search_server/src/llm_backend/model_fetch.rs
+++ b/fire_seq_search_server/src/llm_backend/model_fetch.rs
@@ -1,0 +1,200 @@
+//! Zero-config embedding model: auto-fetch the pinned bge-m3 llamafile.
+//!
+//! The embedding model is not the user's problem. Rather than asking them to
+//! download a GGUF and point `--embed-model` at it, we ship bge-m3 as a
+//! self-contained llamafile on GitHub Releases and fetch it once into the
+//! per-user cache. The spawn layer then launches it like any other model
+//! (the `.llamafile` extension switches it into llamafile mode).
+//!
+//! Pinned by URL **and** SHA-256: an auto-download must never silently swap
+//! the embedding model out from under an existing index — a different model
+//! produces incompatible vectors, which would poison cosine similarity
+//! against everything already stored.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use futures::StreamExt;
+use log::{info, warn};
+use sha2::{Digest, Sha256};
+
+use super::LlmError;
+
+/// Pinned bge-m3 embedding model, packaged as a self-contained llamafile.
+/// Built from <https://github.com/Endle/bge-m3-llamafile> and published on its
+/// GitHub Releases. Update all three constants together when bumping the pin.
+const BGE_M3_URL: &str =
+    "https://github.com/Endle/bge-m3-llamafile/releases/download/20260625/bge-m3.llamafile";
+const BGE_M3_SHA256: &str =
+    "7a2f47411ce8624f7a56190a74e6d0089481ff91fa3fed4b76795008711855ec";
+/// Cached filename. The `.llamafile` extension is load-bearing: the spawn
+/// layer keys off it to launch in llamafile mode (no `--model` arg, since the
+/// weights are baked into the binary).
+const BGE_M3_FILENAME: &str = "bge-m3.llamafile";
+
+fn cache_dir() -> PathBuf {
+    PathBuf::from(shellexpand::tilde("~/.cache/fire_seq_search").as_ref())
+}
+
+/// Ensure the pinned bge-m3 llamafile is present and intact in the cache,
+/// downloading it once if needed. Returns the path to use as the embed model.
+///
+/// Idempotent: a cached file whose SHA-256 already matches is returned without
+/// touching the network. A cached file that fails the hash (truncated download
+/// from a previous crash, or a stale pin from an older build) is re-fetched.
+pub async fn ensure_bge_m3() -> Result<PathBuf, LlmError> {
+    let dir = cache_dir();
+    let dest = dir.join(BGE_M3_FILENAME);
+
+    if dest.exists() {
+        match sha256_file(&dest) {
+            Ok(h) if h == BGE_M3_SHA256 => {
+                info!("bge-m3 llamafile present and verified at {}", dest.display());
+                return Ok(dest);
+            }
+            Ok(h) => warn!(
+                "cached bge-m3 llamafile hash mismatch ({} != expected), re-downloading",
+                h
+            ),
+            Err(e) => warn!("cannot hash cached bge-m3 llamafile ({}), re-downloading", e),
+        }
+    }
+
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| LlmError::Config(format!("create cache dir {}: {}", dir.display(), e)))?;
+
+    info!(
+        "fetching bge-m3 embedding model (~723 MB, one-time) from {} into {}",
+        BGE_M3_URL,
+        dest.display()
+    );
+
+    // Download to a sibling temp file so the final rename is atomic (same
+    // filesystem). A crash mid-download then can't leave a truncated file at
+    // the real path that the exists() check above would later trust.
+    let tmp = dir.join(format!("{}.part", BGE_M3_FILENAME));
+    let hash = download_to(&tmp, BGE_M3_URL).await?;
+
+    if hash != BGE_M3_SHA256 {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(LlmError::Config(format!(
+            "bge-m3 download hash mismatch: got {}, expected {}",
+            hash, BGE_M3_SHA256
+        )));
+    }
+
+    // llamafile is an executable APE binary. We invoke it via `sh` in the
+    // spawn layer (which works regardless), but set +x anyway so a future
+    // binfmt_misc / direct-exec path also works.
+    set_executable(&tmp)?;
+    std::fs::rename(&tmp, &dest)
+        .map_err(|e| LlmError::Config(format!("install bge-m3 llamafile: {}", e)))?;
+    info!("bge-m3 llamafile ready at {}", dest.display());
+    Ok(dest)
+}
+
+/// Stream `url` to `path`, returning the lowercase hex SHA-256 of the bytes
+/// written. Hashes on the fly so a 723 MB file is never re-read just to verify.
+async fn download_to(path: &Path, url: &str) -> Result<String, LlmError> {
+    let client = reqwest::Client::builder()
+        // No overall timeout — this is a multi-hundred-MB download over an
+        // arbitrary link. A connect timeout still fails a dead host fast
+        // instead of hanging startup forever.
+        .connect_timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| LlmError::Config(e.to_string()))?;
+
+    let resp = client.get(url).send().await?;
+    if !resp.status().is_success() {
+        return Err(LlmError::Config(format!(
+            "download {} failed: HTTP {}",
+            url,
+            resp.status()
+        )));
+    }
+
+    let mut file = std::fs::File::create(path)
+        .map_err(|e| LlmError::Config(format!("create {}: {}", path.display(), e)))?;
+    let mut hasher = Sha256::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .map_err(|e| LlmError::Config(format!("write {}: {}", path.display(), e)))?;
+    }
+    file.flush()
+        .map_err(|e| LlmError::Config(format!("flush {}: {}", path.display(), e)))?;
+    Ok(hex(&hasher.finalize()))
+}
+
+fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex(&hasher.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{:02x}", b);
+    }
+    s
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), LlmError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .map_err(|e| LlmError::Config(format!("chmod +x {}: {}", path.display(), e)))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), LlmError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_encodes_lowercase_zero_padded() {
+        assert_eq!(hex(&[0x00, 0x0f, 0xa2, 0xff]), "000fa2ff");
+        assert_eq!(hex(&[]), "");
+    }
+
+    #[test]
+    fn sha256_file_matches_known_vector() {
+        // SHA-256 of the empty input.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("empty");
+        std::fs::write(&p, b"").unwrap();
+        assert_eq!(
+            sha256_file(&p).unwrap(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_file_matches_known_vector_abc() {
+        // SHA-256("abc") — the canonical FIPS-180 test vector.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("abc");
+        std::fs::write(&p, b"abc").unwrap();
+        assert_eq!(
+            sha256_file(&p).unwrap(),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+}

--- a/fire_seq_search_server/src/llm_backend/model_fetch.rs
+++ b/fire_seq_search_server/src/llm_backend/model_fetch.rs
@@ -50,7 +50,8 @@ pub async fn ensure_bge_m3() -> Result<PathBuf, LlmError> {
     if dest.exists() {
         match sha256_file(&dest) {
             Ok(h) if h == BGE_M3_SHA256 => {
-                info!("bge-m3 llamafile present and verified at {}", dest.display());
+                info!("bge-m3 llamafile sha256 matches");
+                info!("bge-m3 llamafile ready at {}", dest.display());
                 return Ok(dest);
             }
             Ok(h) => warn!(
@@ -83,6 +84,7 @@ pub async fn ensure_bge_m3() -> Result<PathBuf, LlmError> {
             hash, BGE_M3_SHA256
         )));
     }
+    info!("bge-m3 llamafile sha256 matches");
 
     // llamafile is an executable APE binary. We invoke it via `sh` in the
     // spawn layer (which works regardless), but set +x anyway so a future

--- a/fire_seq_search_server/src/llm_backend/process.rs
+++ b/fire_seq_search_server/src/llm_backend/process.rs
@@ -71,8 +71,12 @@ async fn spawn(
         c.arg(&model_path)
             .arg("--server")
             .arg("--port")
-            .arg(port.to_string())
-            .arg("--nobrowser");
+            .arg(port.to_string());
+        // NB: no --nobrowser. The pinned bge-m3 llamafile is built on a newer
+        // llama.cpp server that rejects that flag ("error: invalid argument:
+        // --nobrowser") and exits immediately, which surfaced only as a 60s
+        // health-check timeout. The newer server doesn't auto-open a browser
+        // in --server mode, so the flag is unnecessary anyway.
         if is_embedding {
             // bge-m3 supports up to 8K-token inputs; raise the physical and
             // logical batch sizes so a single chunk can be embedded in one

--- a/fire_seq_search_server/src/main.rs
+++ b/fire_seq_search_server/src/main.rs
@@ -48,8 +48,12 @@ struct Cli {
     #[arg(long)]
     chat_endpoint: Option<String>,
 
-    #[arg(long, default_value = "~/llm/bge-m3-Q4_K_M.gguf")]
-    embed_model: PathBuf,
+    /// Path to the embedding model. Omit (the default) to auto-download the
+    /// pinned bge-m3 llamafile into `~/.cache/fire_seq_search` and use it —
+    /// zero-config embedding. Pass an explicit path to use your own GGUF/
+    /// llamafile instead. Ignored when `--embed-endpoint` is set.
+    #[arg(long)]
+    embed_model: Option<PathBuf>,
 
     #[arg(long, default_value = "~/llm/Qwen3.5-9B-UD-Q4_K_XL.gguf")]
     chat_model: PathBuf,
@@ -113,7 +117,13 @@ async fn main() {
 
     info!("main thread running");
     let matches = Cli::parse();
-    let llm_cfg = build_llm_config(&matches);
+    let llm_cfg = match build_llm_config(&matches).await {
+        Ok(c) => c,
+        Err(e) => {
+            error!("LLM config failed: {}", e);
+            std::process::exit(1);
+        }
+    };
     let server_info: ServerInformation = build_server_info(&matches);
 
     let notebook_name = server_info.notebook_name.clone();
@@ -200,14 +210,23 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-fn build_llm_config(args: &Cli) -> LlmBackendConfig {
+async fn build_llm_config(args: &Cli) -> Result<LlmBackendConfig, fire_seq_search_server::llm_backend::LlmError> {
     let embed = match &args.embed_endpoint {
         Some(url) => EndpointSource::External(url.clone()),
-        None => EndpointSource::Spawn {
-            model: args.embed_model.clone(),
-            port: args.embed_port,
-            extra_args: build_spawn_args(args.embed_gpu_layers, &args.embed_extra_args),
-        },
+        None => {
+            // No explicit --embed-model → auto-fetch the pinned bge-m3
+            // llamafile so embedding is zero-config. An explicit path is
+            // used verbatim (BYO GGUF/llamafile).
+            let model = match &args.embed_model {
+                Some(p) => p.clone(),
+                None => fire_seq_search_server::llm_backend::model_fetch::ensure_bge_m3().await?,
+            };
+            EndpointSource::Spawn {
+                model,
+                port: args.embed_port,
+                extra_args: build_spawn_args(args.embed_gpu_layers, &args.embed_extra_args),
+            }
+        }
     };
     let chat = match &args.chat_endpoint {
         Some(url) => EndpointSource::External(url.clone()),
@@ -217,13 +236,13 @@ fn build_llm_config(args: &Cli) -> LlmBackendConfig {
             extra_args: build_spawn_args(args.chat_gpu_layers, &args.chat_extra_args),
         },
     };
-    LlmBackendConfig {
+    Ok(LlmBackendConfig {
         embed,
         chat,
         embed_model_name: args.embed_model_name.clone(),
         chat_model_name: args.chat_model_name.clone(),
         llama_server_bin: args.llama_server_bin.clone(),
-    }
+    })
 }
 
 fn split_extra_args(s: &str) -> Vec<String> {


### PR DESCRIPTION
## Summary

Adds zero-config embedding: with no `--embed-model`/`--embed-endpoint`, the server auto-downloads a pinned `bge-m3` llamafile (URL + SHA-256 in `llm_backend/model_fetch.rs`) into `~/.cache/fire_seq_search` and spawns it.

Two commits:
- **`92a0fde`** — the auto-download itself (`model_fetch.rs`, wired into `main.rs`).
- **`b72313b`** — startup fix: the pinned bge-m3 llamafile is built on a newer llama.cpp server that rejects `--nobrowser` (`error: invalid argument: --nobrowser`) and exits immediately, surfacing only as a 60s health-check timeout. Removed the flag (the newer server doesn't auto-open a browser in `--server` mode). Also logs `bge-m3 llamafile sha256 matches` before `ready at` on both the fresh-download and cached paths.

## Test

Live `fsq-smoke` against the Logseq corpus (2454 notes / 2390 chunks):
- Embed backend healthy in 17s — no "failed to start" / "not responsive within 60s".
- Both new log lines present.
- `/query "rust"` returns correctly ranked hits (dense peak `top=0.586`), summaries mostly `ok`, none `failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)