### PR TITLE
Prep crate for crates.io publish (cargo install)

### DIFF
--- a/fire_seq_search_server/Cargo.lock
+++ b/fire_seq_search_server/Cargo.lock
@@ -257,17 +257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,12 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,15 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -557,8 +531,6 @@ dependencies = [
  "kill_tree",
  "lazy_static",
  "log",
- "pdf-extract-temporary-mitigation-panic",
- "pulldown-cmark",
  "regex",
  "reqwest",
  "rusqlite",
@@ -1033,12 +1005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,22 +1025,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "lopdf"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0f69c40d6dbc68ebac4bf5aec3d9978e094e22e29fcabd045acd9cec74a9dc"
-dependencies = [
- "encoding",
- "flate2",
- "itoa",
- "linked-hash-map",
- "log",
- "pom 3.4.0",
- "time",
- "weezl",
-]
 
 [[package]]
 name = "matchit"
@@ -1178,15 +1128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1721,67 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "strsim"

--- a/fire_seq_search_server/Cargo.toml
+++ b/fire_seq_search_server/Cargo.toml
@@ -3,6 +3,19 @@ name = "fire_seq_search_server"
 version = "1.0.1"
 edition = "2021"
 license = "MIT"
+description = "Local semantic search and RAG server over your Logseq or Obsidian notes, surfaced in your search engine via a browser extension."
+repository = "https://github.com/Endle/fireSeqSearch"
+homepage = "https://github.com/Endle/fireSeqSearch"
+readme = "README.md"
+keywords = ["logseq", "obsidian", "search", "semantic", "rag"]
+categories = ["command-line-utilities", "text-processing"]
+# Ship only what `cargo install` needs. Dev scripts, the cargo-deny config,
+# and the test fixture tree (incl. a screenshot PNG) don't belong in the crate.
+exclude = [
+    "tests/",
+    "*.sh",
+    "deny.toml",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fire_seq_search_server/README.md
+++ b/fire_seq_search_server/README.md
@@ -1,0 +1,52 @@
+# fire_seq_search_server
+
+The backend for [fireSeqSearch](https://github.com/Endle/fireSeqSearch) — local
+semantic search and RAG over your **Logseq** or **Obsidian** notes.
+
+It runs a small local HTTP server that does dense semantic retrieval over your
+notebook plus per-page LLM-generated summaries. Paired with the fireSeqSearch
+browser extension, it appends hits from your personal notes to your search
+engine results, and can answer questions grounded in those notes — all local.
+
+## Install
+
+```sh
+cargo install fire_seq_search_server
+```
+
+## Run
+
+```sh
+# Logseq (default flavour)
+fire_seq_search_server --notebook-path ~/logseq
+
+# Obsidian
+fire_seq_search_server --notebook obsidian --notebook-path ~/vault
+```
+
+On first run, with no embedding model configured, the server auto-downloads a
+pinned `bge-m3` llamafile (~one-time, several hundred MB) into
+`~/.cache/fire_seq_search` and spawns it for embeddings. See the flags below to
+point at an existing llama-server / Ollama instead.
+
+Once running, the server listens on `127.0.0.1:3030`. Point the fireSeqSearch
+browser extension at it, or query it directly:
+
+```sh
+curl http://127.0.0.1:3030/query/rust
+```
+
+## Configuration
+
+Run `fire_seq_search_server --help` for the full flag list, including
+`--embed-endpoint` / `--chat-endpoint` (use a pre-running llama-server, Ollama,
+or a remote OpenAI-compatible server) and `--chat <preset>`.
+
+## Documentation & source
+
+Full documentation, the browser extension, and development notes live in the
+main repository: <https://github.com/Endle/fireSeqSearch>
+
+## License
+
+MIT © Zhenbo Li


### PR DESCRIPTION
Add the metadata crates.io requires/expects and trim the published tarball to what `cargo install fire_seq_search_server` actually needs.

- Cargo.toml: add description, repository, homepage, readme, keywords, categories. `description` is a hard upload requirement; without it crates.io rejects the publish.
- Cargo.toml: exclude dev scripts, deny.toml, and the tests/ fixture tree (incl. a screenshot PNG) from the package. Published tarball is now README + src + manifests only.
- Add crate-local README.md (install + run + config) so the crates.io page isn't blank.
