### PR TITLE
Docs + CI for the cargo install path

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,71 @@
+name: Install
+
+# Verifies the `cargo install fire_seq_search_server` path end to end: that the
+# crate tarball installs, and that the resulting binary is on PATH and runs.
+#
+# Master + manual only, deliberately. This is a release-profile build with a
+# bundled SQLite compiled from C, so it costs minutes rather than seconds, and
+# ci.yml's `cargo test` + `cargo package` already gate every PR.
+#
+# Linux + macOS, because the bundled-SQLite C build and the ~/.cargo/bin PATH
+# setup are the platform-specific parts, and those are the two platforms users
+# actually `cargo install` on.
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  # Never cancel a master run mid-flight; github.run_id gives each commit its
+  # own group. Matches ci.yml.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    name: cargo install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform failing shouldn't hide the other's result.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    defaults:
+      run:
+        working-directory: fire_seq_search_server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fire_seq_search_server
+
+      # --no-verify because the install below compiles the same tree anyway;
+      # ci.yml runs the verifying `cargo package` on every PR.
+      - name: Package
+        run: cargo package --locked --no-verify
+
+      # Install from the *extracted tarball*, not `--path .`. `cargo install
+      # --path` ignores Cargo.toml's `exclude`, so it would happily build
+      # against files that never ship to crates.io — exactly the breakage this
+      # job exists to catch. The tarball is what users actually get.
+      - name: Install from the packaged tarball
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          cargo install --locked --path "target/package/fire_seq_search_server-${version}"
+
+      # Bare command, no ./target path: proves ~/.cargo/bin is on PATH and the
+      # binary starts. --version is clap-derived from CARGO_PKG_VERSION.
+      - name: Verify the installed binary
+        working-directory: .
+        run: fire_seq_search_server --version

--- a/README.md
+++ b/README.md
@@ -67,25 +67,40 @@ Built and tested against current Rust stable; see
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 ```
-git clone https://github.com/Endle/fireSeqSearch
-cd fireSeqSearch/fire_seq_search_server
-cargo build --release
+cargo install fire_seq_search_server
 ```
+
+This puts `fire_seq_search_server` on your `PATH` (in `~/.cargo/bin`). The
+first install builds a bundled SQLite from source, so expect it to take a few
+minutes.
 
 #### Logseq
 
 ```
-./target/release/fire_seq_search_server --notebook-path /home/you/logseq_notebook
+fire_seq_search_server --notebook-path /home/you/logseq_notebook
 ```
 
 #### Obsidian
 
 ```
-./target/release/fire_seq_search_server --notebook-path /home/you/vault --notebook obsidian
+fire_seq_search_server --notebook-path /home/you/vault --notebook obsidian
 ```
 
 The server hosts endpoints on `http://127.0.0.1:3030`. The extension talks to
 it from your browser.
+
+#### Building from source instead
+
+For development, or to run an unreleased revision:
+
+```
+git clone https://github.com/Endle/fireSeqSearch
+cd fireSeqSearch/fire_seq_search_server
+cargo build --release
+```
+
+The binary lands at `target/release/fire_seq_search_server` — use that path in
+place of the bare command above.
 
 ### 3. Browser extension
 


### PR DESCRIPTION
`fire_seq_search_server` 1.0.1 is [on crates.io](https://crates.io/crates/fire_seq_search_server) now, so `cargo install` is the primary way to get the server. Two changes follow from that.

## README

Section 2 leads with `cargo install fire_seq_search_server` and notes that it lands on `PATH` in `~/.cargo/bin` (plus a heads-up that the first install compiles bundled SQLite, so it takes a few minutes). The Logseq/Obsidian examples drop their `./target/release/` prefix.

Build-from-source moves to a `#### Building from source instead` subsection rather than being deleted — it's still the development path.

`fire_seq_search_server/README.md` (the crates.io landing page) already had this right from #177 and is untouched.

## New `Install` workflow

Verifies the install path end to end on **ubuntu-latest** and **macos-14**: package, install, then run the binary as a bare command to prove PATH placement and startup.

Two decisions worth review:

- **Installs from the extracted package tarball, not `cargo install --path .`.** `--path` ignores `Cargo.toml`'s `exclude`, so it would happily build against files that never ship to crates.io. Now that `tests/`, `*.sh`, and `deny.toml` are excluded, that's exactly the class of breakage this job exists to catch. The version is read via `cargo metadata` + `jq`, so it needs no bumping.
- **Master + `workflow_dispatch` only, not PRs.** It's a release-profile build with a bundled SQLite compiled from C — minutes, not seconds — and `ci.yml` already gates every PR with `cargo test` on three platforms plus a verifying `cargo package`. `--no-verify` on the package step here since the install recompiles the same tree anyway.

## Verified locally (macOS)

- `cargo package --locked --no-verify` → 28 files, 286.4 KiB
- installed from the extracted tarball into a throwaway `--root` → clean release build
- `fire_seq_search_server --version` → `fire_seq_search_server 1.0.1`, exit 0

Note this workflow tests the *source tree's* installability, not the published registry artifact — installing from crates.io on a master push would only re-test whatever is already published. A post-publish registry check would be a separate scheduled job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)